### PR TITLE
Serialize formula if present

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -2930,6 +2930,9 @@ function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
 			}
 			o.t = "str"; break;
 	}
+	if (cell.f) {
+		v = writetag('f',escapexml(cell.f)) + v;
+	}
 	return writextag('c', v, o);
 }
 


### PR DESCRIPTION
It seems to be important that the <f>..</f> comes before the <v>..</v>

This seems to work in a round-trip on a couple of formulae I tried.
