### PR TITLE
fix parse_si for Japanese excel files

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -2031,7 +2031,7 @@ function parse_si(x, opts) {
 	/* 18.4.4 r CT_RElt (Rich Text Run) */
 	else if((y = x.match(sirregex))) {
 		z.r = x;
-		z.t = utf8read(unescapexml(x.match(sitregex).join("").replace(tagregex,"")));
+		z.t = utf8read(unescapexml(x.replace(/<rPh.*?>(.*?)<\/rPh>/g, '').match(sitregex).join("").replace(tagregex,"")));
 		if(html) z.h = parse_rs(x);
 	}
 	/* 18.4.3 phoneticPr CT_PhoneticPr (TODO: needed for Asian support) */


### PR DESCRIPTION
 Hi.

using #parse_si 'Phonetic Properties' items for Japanese excel files,
the Phonetic items(KATAKANA) represents pronunciation hints of String(KANJI).

``` xml
<si>
 <t>漢字(japanese KANJI)</t>
 <rPh>
  <t>フリガナ(this is KATAKANA for pronounciation:漢字)</t>
 </rPh>
</si>
```

It expected get '漢字' . but got '漢字フリガナ'.
so replace these string, because this can be caused by only `<rPh>`.
