### PR TITLE
Add dependency in bower to packaged jszip

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "js-xlsx",
   "homepage": "https://github.com/SheetJS/js-xlsx",
-  "main": "dist/xlsx.js",
+  "main": ["dist/jszip.js","dist/xlsx.js"],
   "version": "0.7.12",
   "ignore": [
     "bin",


### PR DESCRIPTION
Fixing issue #165. This will enable devs to just bower install the package without also needing to install jszip (in the correct order)
