### PR TITLE
Make `bower.json`'s "main" point to `./xlsx.js` instead of `dist/xlsx.js`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "js-xlsx",
   "homepage": "https://github.com/SheetJS/js-xlsx",
-  "main": "dist/xlsx.js",
+  "main": "./xlsx.js",
   "version": "0.8.0",
   "ignore": [
     "bin",


### PR DESCRIPTION
I'm using Browserify and [debowerify](https://github.com/eugeneware/debowerify).

Inside [`bower.json:4`](https://github.com/SheetJS/js-xlsx/blob/master/bower.json#L4), `main` points to `dist/xlsx.js` as opposed to [`package.json:10`](https://github.com/SheetJS/js-xlsx/blob/master/package.json#L10) that points to `./xlsx`.

This trows a '"Cannot find module"' error becasue `./dist/dist/cpexcel` does not exists as required in [`/dist/xlsx.js:10`](https://github.com/stefanmaric/js-xlsx/blob/master/dist/xlsx.js#L10).

This pull request fixes the error.

PD: minor typo in commit message.
