### PR TITLE
Fix SST parsing when SST XML has a tag prefix

### DIFF
--- a/bits/42_sstxml.js
+++ b/bits/42_sstxml.js
@@ -135,15 +135,15 @@ var parse_rs = (function parse_rs_factory() {
 })();
 
 /* 18.4.8 si CT_Rst */
-var sitregex = /<t[^>]*>([^<]*)<\/t>/g, sirregex = /<r>/;
+var sitregex = /<(?:\w+:)?t[^>]*>([^<]*)<\/(?:\w+:)?t>/g, sirregex = /<(?:\w+:)?r>/;
 function parse_si(x, opts) {
 	var html = opts ? opts.cellHTML : true;
 	var z = {};
 	if(!x) return null;
 	var y;
 	/* 18.4.12 t ST_Xstring (Plaintext String) */
-	if(x.charCodeAt(1) === 116) {
-		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/t>/)[0]));
+	if ((y = x.match(/^<(?:\w+:)?t/))) {
+		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/(?:\w+:)?t>/)[0]));
 		z.r = x;
 		if(html) z.h = z.t;
 	}
@@ -159,9 +159,9 @@ function parse_si(x, opts) {
 }
 
 /* 18.4 Shared String Table */
-var sstr0 = /<sst([^>]*)>([\s\S]*)<\/sst>/;
-var sstr1 = /<(?:si|sstItem)>/g;
-var sstr2 = /<\/(?:si|sstItem)>/;
+var sstr0 = /<(?:\w+:)?sst([^>]*)>([\s\S]*)<\/(?:\w+:)?sst>/;
+var sstr1 = /<(?:\w+:)?(?:si|sstItem)>/g;
+var sstr2 = /<\/(?:\w+:)?(?:si|sstItem)>/;
 function parse_sst_xml(data, opts) {
 	var s = [], ss;
 	/* 18.4.9 sst CT_Sst */

--- a/xlsx.js
+++ b/xlsx.js
@@ -4260,15 +4260,15 @@ var parse_rs = (function parse_rs_factory() {
 })();
 
 /* 18.4.8 si CT_Rst */
-var sitregex = /<t[^>]*>([^<]*)<\/t>/g, sirregex = /<r>/;
+var sitregex = /<(?:\w+:)?t[^>]*>([^<]*)<\/(?:\w+:)?t>/g, sirregex = /<(?:\w+:)?r>/;
 function parse_si(x, opts) {
 	var html = opts ? opts.cellHTML : true;
 	var z = {};
 	if(!x) return null;
 	var y;
 	/* 18.4.12 t ST_Xstring (Plaintext String) */
-	if(x.charCodeAt(1) === 116) {
-		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/t>/)[0]));
+	if ((y = x.match(/^<(?:\w+:)?t/))) {
+		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/(?:\w+:)?t>/)[0]));
 		z.r = x;
 		if(html) z.h = z.t;
 	}
@@ -4284,9 +4284,9 @@ function parse_si(x, opts) {
 }
 
 /* 18.4 Shared String Table */
-var sstr0 = /<sst([^>]*)>([\s\S]*)<\/sst>/;
-var sstr1 = /<(?:si|sstItem)>/g;
-var sstr2 = /<\/(?:si|sstItem)>/;
+var sstr0 = /<(?:\w+:)?sst([^>]*)>([\s\S]*)<\/(?:\w+:)?sst>/;
+var sstr1 = /<(?:\w+:)?(?:si|sstItem)>/g;
+var sstr2 = /<\/(?:\w+:)?(?:si|sstItem)>/;
 function parse_sst_xml(data, opts) {
 	var s = [], ss;
 	/* 18.4.9 sst CT_Sst */


### PR DESCRIPTION
XLSX documents written by DocumentFormat.OpenXml.dll (at least sometimes) contain a tag prefix "x" in the sharedStrings.xml file. This is a fix to the regular expressions that parse this file to handle the prefix if it is present.
