### PR TITLE
added compression option to the write file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Assuming `workbook` is a workbook object:
 
 ```
 /* output format determined by filename */
-XLSX.writeFile(workbook, 'out.xlsx');
+XLSX.writeFile(workbook, 'out.xlsx', {compression: 'DEFLATE'});
 /* at this point, out.xlsx is a file that you can distribute */
 ```
 
@@ -230,7 +230,7 @@ XLSX.writeFile(workbook, 'out.xlsx');
 
 ```
 /* bookType can be 'xlsx' or 'xlsm' or 'xlsb' */
-var wopts = { bookType:'xlsx', bookSST:false, type:'binary' };
+var wopts = { bookType:'xlsx', bookSST:false, type:'binary', compression: 'DEFLATE' };
 
 var wbout = XLSX.write(workbook,wopts);
 

--- a/xlsx.js
+++ b/xlsx.js
@@ -11403,14 +11403,21 @@ function readFileSync(data, opts) {
 	return readSync(data, o);
 }
 function write_zip_type(wb, opts) {
-	var o = opts||{};
-	var z = write_zip(wb, o);
-	switch(o.type) {
-		case "base64": return z.generate({type:"base64"});
-		case "binary": return z.generate({type:"string"});
-		case "buffer": return z.generate({type:"nodebuffer"});
-		case "file": return _fs.writeFileSync(o.file, z.generate({type:"nodebuffer"}));
-		default: throw new Error("Unrecognized type " + o.type);
+	var o = {}, z;
+	opts = opts||{};
+	z = write_zip(wb, opts);
+	
+	switch(opts.type) {
+		case "base64": o.type = "base64"; if (typeof opts.compression === 'string') {o.compression = opts.compression;} break;
+		case "binary": o.type = "string"; if (typeof opts.compression === 'string') {o.compression = opts.compression;} break;
+		case "buffer": o.type = "nodebuffer"; if (typeof opts.compression === 'string') {o.compression = opts.compression;} break;
+		case "file": o.type = "nodebuffer"; if (typeof opts.compression === 'string') {o.compression = opts.compression;} break;
+		default: throw new Error("Unrecognized type " + opts.type);
+	}
+	
+	switch(opts.type) {
+		case "file": return _fs.writeFileSync(opts.file, z.generate(o));
+		default: return z.generate(o);
 	}
 }
 


### PR DESCRIPTION
By adding a compression option to writeFile this will now allow us to override the default behavior of JSZip which is to STORE (no compression). 

Example usage:
XLSX.writeFile(wb, 'out.xlsx', {compression: 'DEFLATE'});