### PR TITLE
Write: Basic support for formulas

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -7388,7 +7388,9 @@ function write_ws_xml_cols(ws, cols) {
 }
 
 function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
-	if(cell.v === undefined) return "";
+	if (cell.v === undefined && ! cell.f) {
+		return '';
+	}
 	var vv = "";
 	var oldt = cell.t, oldv = cell.v;
 	switch(cell.t) {
@@ -7405,7 +7407,10 @@ function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
 			break;
 		default: vv = cell.v; break;
 	}
-	var v = writetag('v', escapexml(vv)), o = {r:ref};
+	var o = { r: ref },
+		v = cell.f ?
+		writetag('f', escapexml(cell.f)) :
+		writetag('v', escapexml(vv));
 	/* TODO: cell style */
 	var os = get_cell_style(opts.cellXfs, cell, opts);
 	if(os !== 0) o.s = os;


### PR DESCRIPTION
Added support for simple formulas while writing xlsx to file:

Based on the patch from @mcsf:
https://github.com/mcsf/js-xlsx/commit/d43964564d2d455271a9348f904fe2c34e5b1a59

Signed-off-by: Alexander Knapstein alexander.knapstein@inspirationlabs.com
