### PR TITLE
Unrecognized rich format <u> |  Unrecognized rich format <b> --- fix

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -4194,6 +4194,7 @@ var parse_rs = (function parse_rs_factory() {
 				case '</strike>': break;
 
 				/* 18.4.13 u CT_UnderlineProperty */
+				case '<u>':
 				case '<u':
 					if(!y.val) break;
 					/* falls through */
@@ -4201,6 +4202,7 @@ var parse_rs = (function parse_rs_factory() {
 				case '</u>': break;
 
 				/* 18.8.2 b */
+				case '<b>':
 				case '<b':
 					if(!y.val) break;
 					/* falls through */


### PR DESCRIPTION
this fix solve this 2 issues

---

node_modules\xlsx\xlsx.js:4234
   if(y[0].charCodeAt(1) !== 47) throw 'Unrecognized rich format ' + y[0];

Unrecognized rich format <b>

---

node_modules\xlsx\xlsx.js:4234
   if(y[0].charCodeAt(1) !== 47) throw 'Unrecognized rich format ' + y[0];

Unrecognized rich format <u>
