### PR TITLE
wbrels[i] can be null

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -11232,7 +11232,7 @@ function parse_zip(zip, opts) {
 	/* Numbers iOS hack */
 	var nmode = (getzipdata(zip,"xl/worksheets/sheet.xml",true))?1:0;
 	for(i = 0; i != props.Worksheets; ++i) {
-		if(wbrels) path = 'xl/' + (wbrels[i][1]).replace(/[\/]?xl\//, "");
+		if(wbrels && wbrels[i]) path = 'xl/' + (wbrels[i][1]).replace(/[\/]?xl\//, "");
 		else {
 			path = 'xl/worksheets/sheet'+(i+1-nmode)+"." + wbext;
 			path = path.replace(/sheet0\./,"sheet.");


### PR DESCRIPTION
![wbrels](https://cloud.githubusercontent.com/assets/4041967/15888032/32dcfb14-2d5d-11e6-933f-fdc651b2efaf.png)

Excels can have various structures populated in unusual ways. I've noticed this error in the field.

Putting a small check should protect against it.
