### PR TITLE
rPh element could be just ignored

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -4261,11 +4261,16 @@ var parse_rs = (function parse_rs_factory() {
 
 /* 18.4.8 si CT_Rst */
 var sitregex = /<t[^>]*>([^<]*)<\/t>/g, sirregex = /<r>/;
+var sirphregex = /<\/rPh>/;
 function parse_si(x, opts) {
 	var html = opts ? opts.cellHTML : true;
 	var z = {};
 	if(!x) return null;
 	var y;
+	/* 18.4.6 rPh CT_PhoneticRun (ignored) */
+	if((y = x.match(sirphregex))) {
+		x = x.replace(/<rPh\W.*?<\/rPh>/g, "");
+	}
 	/* 18.4.12 t ST_Xstring (Plaintext String) */
 	if(x.charCodeAt(1) === 116) {
 		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/t>/)[0]));


### PR DESCRIPTION
The xlsx.js currently does not support 18.4.6 rPh CT_PhoneticRun.
This patch just removes  `<rPh>` element to avoid parsing needless phonetic string.

``` xml
<?xml version="1.0" encodingx="UTF-8" standalone="yes"?>
<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
  <si>
    <t>** original string **</t>
    <rPh sb="X" eb="Y">
      <t>** phonetic string **</t>
    </rPh>
    <phoneticPr fontId="1"/>
  </si>
</sst>
```

See also similar patch for Perl module:
http://blog.remora.cx/2010/03/annoying-cell-value-with-furigana.html
