### PR TITLE
Setting 'state' attribute in 'sheet' tag so that a sheet can be hidden or made visible.

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -8238,7 +8238,7 @@ function write_wb_xml(wb, opts) {
 	o[o.length] = (writextag('workbookPr', null, {date1904:safe1904(wb)}));
 	o[o.length] = "<sheets>";
 	for(var i = 0; i != wb.SheetNames.length; ++i)
-		o[o.length] = (writextag('sheet',null,{name:wb.SheetNames[i].substr(0,31), sheetId:""+(i+1), "r:id":"rId"+(i+1)}));
+		o[o.length] = (writextag('sheet',null,{name:wb.SheetNames[i].substr(0,31), sheetId:""+(i+1), "r:id":"rId"+(i+1), state: wb.Workbook.Sheets[i].state}));
 	o[o.length] = "</sheets>";
 	if(o.length>2){ o[o.length] = '</workbook>'; o[1]=o[1].replace("/>",">"); }
 	return o.join("");


### PR DESCRIPTION
Fixed issue where state attribute of sheet was being ignored and not included in generated xml.  Setting the state attribute allows users to hide or make a sheet visible.