### PR TITLE
upgrade codepage 1.3.6 -> 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"main": "./xlsx",
 	"dependencies": {
 		"ssf":"~0.8.1",
-		"codepage":"~1.3.6",
+		"codepage":"~1.6.0",
 		"cfb":">=0.10.0",
 		"jszip":"2.4.0",
 		"crc-32":"",


### PR DESCRIPTION
because in 1.3.6  displays warning
`npm WARN prefer global voc@0.5.0 should be installed with -g`