### PR TITLE
fixing an issue where _xd_ is getting escaped

### DIFF
--- a/bits/22_xmlutils.js
+++ b/bits/22_xmlutils.js
@@ -32,7 +32,8 @@ var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
 var unescapexml/*:StringConv*/ = (function() {
-	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+	/* 22.4.2.4 bstr (Basic String) */
+	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 	return function unescapexml(text/*:string*/)/*:string*/ {
 		var s = text + '';
 		return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});

--- a/ods.flow.js
+++ b/ods.flow.js
@@ -116,7 +116,8 @@ var rencoding = {
 var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
-var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+/* 22.4.2.4 bstr (Basic String) */
+var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 function unescapexml(text){
 	var s = text + '';
 	return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});

--- a/ods.js
+++ b/ods.js
@@ -114,7 +114,8 @@ var rencoding = {
 var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
-var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+/* 22.4.2.4 bstr (Basic String) */
+var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 function unescapexml(text){
 	var s = text + '';
 	return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});

--- a/odsbits/22_xmlutils.js
+++ b/odsbits/22_xmlutils.js
@@ -44,7 +44,8 @@ var rencoding = {
 var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
-var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+/* 22.4.2.4 bstr (Basic String) */
+var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 function unescapexml(text){
 	var s = text + '';
 	return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -1457,7 +1457,8 @@ var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
 var unescapexml/*:StringConv*/ = (function() {
-	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+	/* 22.4.2.4 bstr (Basic String) */
+	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 	return function unescapexml(text/*:string*/)/*:string*/ {
 		var s = text + '';
 		return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});

--- a/xlsx.js
+++ b/xlsx.js
@@ -1415,7 +1415,8 @@ var rencstr = "&<>'\"".split("");
 
 // TODO: CP remap (need to read file version to determine OS)
 var unescapexml = (function() {
-	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]+)_/g;
+	/* 22.4.2.4 bstr (Basic String) */
+	var encregex = /&[a-z]*;/g, coderegex = /_x([\da-fA-F]{4})_/g;
 	return function unescapexml(text) {
 		var s = text + '';
 		return s.replace(encregex, function($$) { return encodings[$$]; }).replace(coderegex,function(m,c) {return String.fromCharCode(parseInt(c,16));});


### PR DESCRIPTION
\_x000D\_ style replacements always have exactly 4 hexadecimal characters.

If in Excel, you type \_xd\_ in a cell, js-xlsx will give this string special treatment, even though Excel doesn't consider it to be significant.If you enter \_x000D\_ in a cell in Excel, the leading underscore will be escaped by Excel as without that it would be treated as an escape.