### PR TITLE
Fix Cell Objects to always have html-encoded data for "h" key

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -1553,6 +1553,10 @@ function escapexml(text, xml){
 	return s.replace(decregex, function(y) { return rencoding[y]; }).replace(charegex,function(s) { return "_x" + ("000"+s.charCodeAt(0).toString(16)).slice(-4) + "_";});
 }
 function escapexmltag(text){ return escapexml(text).replace(/ /g,"_x0020_"); }
+function escapehtml(text){
+	var s = text + '';
+	return s.replace(decregex, function(y) { return rencoding[y]; });
+}
 
 /* TODO: handle codepages */
 var xlml_fixstr = (function() {
@@ -5718,7 +5722,7 @@ function parse_si(x, opts) {
 	if(x.match(/^\s*<(?:\w+:)?t[^>]*>/)) {
 		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/(?:\w+:)?t>/)[0]));
 		z.r = utf8read(x);
-		if(html) z.h = escapexml(z.t);
+		if(html) z.h = escapehtml(z.t);
 	}
 	/* 18.4.4 r CT_RElt (Rich Text Run) */
 	else if((y = x.match(sirregex))) {
@@ -10133,7 +10137,7 @@ return function parse_ws_xml_data(sdata, s, opts, guess, themes, styles) {
 				case 'str':
 					p.t = "s";
 					p.v = (p.v!=null) ? utf8read(p.v) : '';
-					if(opts.cellHTML) p.h = escapexml(p.v);
+					if(opts.cellHTML) p.h = escapehtml(p.v);
 					break;
 				case 'inlineStr':
 					cref = d.match(isregex);

--- a/xlsx.js
+++ b/xlsx.js
@@ -5718,7 +5718,7 @@ function parse_si(x, opts) {
 	if(x.match(/^\s*<(?:\w+:)?t[^>]*>/)) {
 		z.t = utf8read(unescapexml(x.substr(x.indexOf(">")+1).split(/<\/(?:\w+:)?t>/)[0]));
 		z.r = utf8read(x);
-		if(html) z.h = z.t;
+		if(html) z.h = escapexml(z.t);
 	}
 	/* 18.4.4 r CT_RElt (Rich Text Run) */
 	else if((y = x.match(sirregex))) {
@@ -10133,7 +10133,7 @@ return function parse_ws_xml_data(sdata, s, opts, guess, themes, styles) {
 				case 'str':
 					p.t = "s";
 					p.v = (p.v!=null) ? utf8read(p.v) : '';
-					if(opts.cellHTML) p.h = p.v;
+					if(opts.cellHTML) p.h = escapexml(p.v);
 					break;
 				case 'inlineStr':
 					cref = d.match(isregex);


### PR DESCRIPTION
Some cases left characters like `&` and `<` unencoded in the "h" key, making it unreliable for direct embedding in html.