### PR TITLE
sheet_to_json with selected range & header: 1 has an array that starts at 0

### DIFF
--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -26,7 +26,7 @@ function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/){
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		switch(header) {
-			case 1: hdr[C] = C; break;
+			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:

--- a/test.js
+++ b/test.js
@@ -1516,6 +1516,15 @@ describe('json output', function() {
 		assert.equal(json5.length, 2); // = 2 records
 		assert.equal(json6.length, 3); // = 4 sheet rows - 1 blank row
 	});
+	it('should have an index that starts with zero when selecting range', function() {
+		var _data = [["S","h","e","e","t","J","S"],[1,2,3,4,5,6,7],[7,6,5,4,3,2,1],[2,3,4,5,6,7,8]];
+		var _ws = X.utils.aoa_to_sheet(_data);
+		var json1 = X.utils.sheet_to_json(_ws, { header:1, raw: true, range: "B1:F3" });
+		assert.equal(json1[0][3], "t");
+		assert.equal(json1[1][0], 2);
+		assert.equal(json1[2][1], 5);
+		assert.equal(json1[2][3], 3);
+	});
 });
 
 describe('csv output', function() {

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -16562,7 +16562,7 @@ function sheet_to_json(sheet/*:Worksheet*/, opts/*:?Sheet2JSONOpts*/){
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		switch(header) {
-			case 1: hdr[C] = C; break;
+			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:

--- a/xlsx.js
+++ b/xlsx.js
@@ -16492,7 +16492,7 @@ function sheet_to_json(sheet, opts){
 		cols[C] = encode_col(C);
 		val = dense ? sheet[R][C] : sheet[cols[C] + rr];
 		switch(header) {
-			case 1: hdr[C] = C; break;
+			case 1: hdr[C] = C - r.s.c; break;
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:


### PR DESCRIPTION
When converting with sheet_to_json and selecting a range and header: 1 the created array had some undefined entries at the start of the array.

e.g. B1:C2 would have an array where the first index with a value would be 1.

For a use case of mine I needed it to start always with 0, which I believe make more sense in general

