### PR TITLE
WIP: Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"xlsx": "./bin/xlsx.njs"
 	},
 	"main": "./xlsx",
+	"types": "types",
 	"browser": {
 		"node": false,
 		"crypto": false,
@@ -27,12 +28,15 @@
 	"devDependencies": {
 		"mocha":"",
 		"xlsjs":"",
-		"@sheetjs/uglify-js":""
+		"@sheetjs/uglify-js":"",
+		"dtslint": "^0.1.2",
+		"typescript": "^2.2.0"
 	},
 	"repository": { "type":"git", "url":"git://github.com/SheetJS/js-xlsx.git" },
 	"scripts": {
 		"pretest": "git submodule init && git submodule update",
-		"test": "make travis"
+		"test": "make travis",
+		"dtslint": "dtslint types"
 	},
 	"config": {
 		"blanket": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,5 @@
-// Type definitions for xlsx
 // Project: https://github.com/SheetJS/js-xlsx
 // Definitions by: themauveavenger <https://github.com/themauveavenger/>, Wolfgang Faust <https://github.com/wolfgang42>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** Attempts to read filename and parse */
 export function readFile(filename: string, opts?: IParsingOptions): IWorkBook;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 // Project: https://github.com/SheetJS/js-xlsx
 // Definitions by: themauveavenger <https://github.com/themauveavenger/>, Wolfgang Faust <https://github.com/wolfgang42>
+// TypeScript Version: 2.2
 
 /** Attempts to read filename and parse */
 export function readFile(filename: string, opts?: IParsingOptions): IWorkBook;
@@ -377,12 +378,12 @@ export interface IWorkSheetCell {
     /**
      * Cell hyperlink object (.Target holds link, .tooltip is tooltip)
      */
-    l?: Object;
+    l?: object;
 
     /**
      * The style/theme of the cell (if applicable)
      */
-    s?: Object;
+    s?: object;
 }
 
 export interface ICell {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,17 +3,17 @@
 // TypeScript Version: 2.2
 
 /** Attempts to read filename and parse */
-export function readFile(filename: string, opts?: IParsingOptions): IWorkBook;
+export function readFile(filename: string, opts?: ParsingOptions): WorkBook;
 /** Attempts to parse data */
-export function read(data: any, opts?: IParsingOptions): IWorkBook;
+export function read(data: any, opts?: ParsingOptions): WorkBook;
 /** Attempts to write workbook data to filename */
-export function writeFile(data: IWorkBook, filename: string, opts?: IWritingOptions): any;
+export function writeFile(data: WorkBook, filename: string, opts?: WritingOptions): any;
 /** Attempts to write the workbook data */
-export function write(data: IWorkBook, opts?: IWritingOptions): any;
+export function write(data: WorkBook, opts?: WritingOptions): any;
 
-export const utils: IUtils;
+export const utils: Utils;
 
-export interface IProperties {
+export interface Properties {
     LastAuthor?: string;
     Author?: string;
     CreatedDate?: Date;
@@ -31,7 +31,7 @@ export interface IProperties {
     SheetNames?: string[];
 }
 
-export interface IParsingOptions {
+export interface ParsingOptions {
     /**
      * Input data encoding
      */
@@ -116,7 +116,7 @@ export interface IParsingOptions {
     password?: string;
 }
 
-export interface IWritingOptions {
+export interface WritingOptions {
     /**
      * Output data encoding
      */
@@ -153,12 +153,12 @@ export interface IWritingOptions {
     compression?: boolean;
 }
 
-export interface IWorkBook {
+export interface WorkBook {
     /**
      * A dictionary of the worksheets in the workbook.
      * Use SheetNames to reference these.
      */
-    Sheets: { [sheet: string]: IWorkSheet };
+    Sheets: { [sheet: string]: WorkSheet };
 
     /**
      * ordered list of the sheet names in the workbook
@@ -169,10 +169,10 @@ export interface IWorkBook {
      * an object storing the standard properties. wb.Custprops stores custom properties.
      * Since the XLS standard properties deviate from the XLSX standard, XLS parsing stores core properties in both places.
      */
-    Props: IProperties;
+    Props: Properties;
 }
 
-export interface IColInfo {
+export interface ColInfo {
     /**
      * Excel's "Max Digit Width" unit, always integral
      */
@@ -194,7 +194,7 @@ export interface IColInfo {
      */
     hidden?: boolean;
 }
-export interface IRowInfo {
+export interface RowInfo {
     /**
      * height in screen pixels
      */
@@ -212,7 +212,7 @@ export interface IRowInfo {
 /**
  * Write sheet protection properties.
  */
-export interface IProtectInfo {
+export interface ProtectInfo {
     /**
      * The password for formats that support password-protected sheets
      * (XLSX/XLSB/XLS). The writer uses the XOR obfuscation method.
@@ -298,7 +298,7 @@ export interface IProtectInfo {
 /**
  * object representing any sheet (worksheet or chartsheet)
  */
-export interface ISheet {
+export interface Sheet {
     '!ref'?: string;
     '!margins'?: {
         left: number,
@@ -313,12 +313,12 @@ export interface ISheet {
 /**
  * object representing the worksheet
  */
-export interface IWorkSheet extends ISheet {
-    [cell: string]: IWorkSheetCell | any;
-    '!cols'?: IColInfo[];
-    '!rows'?: IRowInfo[];
-    '!merges'?: IRange[];
-    '!protect'?: IProtectInfo;
+export interface WorkSheet extends Sheet {
+    [cell: string]: WorkSheetCell | any;
+    '!cols'?: ColInfo[];
+    '!rows'?: RowInfo[];
+    '!merges'?: Range[];
+    '!protect'?: ProtectInfo;
     '!autofilter'?: {ref: string};
 }
 
@@ -328,7 +328,7 @@ export interface IWorkSheet extends ISheet {
  */
 export type ExcelDataType = 'b' | 'n' | 'e' | 's' | 'd';
 
-export interface IWorkSheetCell {
+export interface WorkSheetCell {
     /**
      * The raw value of the cell.
      */
@@ -386,50 +386,50 @@ export interface IWorkSheetCell {
     s?: object;
 }
 
-export interface ICell {
+export interface Cell {
     /** Column number */
     c: number;
     /** Row number */
     r: number;
 }
 
-export interface IRange {
+export interface Range {
     /** Starting cell */
-    s: ICell;
+    s: Cell;
     /** Ending cell */
-    e: ICell;
+    e: Cell;
 }
 
-export interface IUtils {
+export interface Utils {
     /** converts an array of arrays of JS data to a worksheet. */
-    aoa_to_sheet<T>(data: T[], opts?: any): IWorkSheet;
+    aoa_to_sheet<T>(data: T[], opts?: any): WorkSheet;
 
     /** Converts a worksheet object to an array of JSON objects */
-    sheet_to_json<T>(worksheet: IWorkSheet, opts?: {
+    sheet_to_json<T>(worksheet: WorkSheet, opts?: {
         raw?: boolean;
         range?: any;
         header?: "A"|number|string[];
     }): T[];
     /** Generates delimiter-separated-values output */
-    sheet_to_csv(worksheet: IWorkSheet, options?: { FS: string, RS: string }): string;
+    sheet_to_csv(worksheet: WorkSheet, options?: { FS: string, RS: string }): string;
     /** Generates a list of the formulae (with value fallbacks) */
-    sheet_to_formulae(worksheet: IWorkSheet): any;
+    sheet_to_formulae(worksheet: WorkSheet): any;
 
     /** Converts 0-indexed cell address to A1 form */
-    encode_cell(cell: ICell): string;
+    encode_cell(cell: Cell): string;
     /** Converts 0-indexed row to A1 form */
     encode_row(row: number): string;
     /** Converts 0-indexed column to A1 form */
     encode_col(col: number): string;
     /** Converts 0-indexed range to A1 form */
-    encode_range(s: ICell, e: ICell): string;
+    encode_range(s: Cell, e: Cell): string;
 
     /** Converts A1 cell address to 0-indexed form */
-    decode_cell(address: string): ICell;
+    decode_cell(address: string): Cell;
     /** Converts A1 row to 0-indexed form */
     decode_row(row: string): number;
     /** Converts A1 column to 0-indexed form */
     decode_col(col: string): number;
     /** Converts A1 range to 0-indexed form */
-    decode_range(range: string): IRange;
+    decode_range(range: string): Range;
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -8,16 +8,10 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": false,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "baseUrl": ".",
+        "paths": { "xlsx": ["."] },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "xlsx-tests.ts"
-    ]
+    }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,6 +1,0 @@
-{
-    "extends": "dtslint/dtslint.json",
-    "rules": {
-        "interface-name": [true, "always-prefix"]
-    }
-}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,5 +1,5 @@
 {
-    "extends": "dtslint/dt.json",
+    "extends": "dtslint/dtslint.json",
     "rules": {
         "interface-name": [true, "always-prefix"]
     }

--- a/types/xlsx-tests.ts
+++ b/types/xlsx-tests.ts
@@ -1,6 +1,6 @@
 import xlsx = require('xlsx');
 
-const options: xlsx.IParsingOptions = {
+const options: xlsx.ParsingOptions = {
     cellDates: true
 };
 
@@ -15,11 +15,11 @@ const firstworksheet = workbook.Sheets[firstsheet];
 
 console.log(firstworksheet["A1"]);
 
-interface ITester {
+interface Tester {
     name: string;
     age: number;
 }
 
-const jsonvalues: ITester[] = xlsx.utils.sheet_to_json<ITester>(firstworksheet);
+const jsonvalues: Tester[] = xlsx.utils.sheet_to_json<Tester>(firstworksheet);
 const csv = xlsx.utils.sheet_to_csv(firstworksheet);
 const formulae = xlsx.utils.sheet_to_formulae(firstworksheet);


### PR DESCRIPTION
This pulls in all of the definitions from [@types/xlsx](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/73c2d769b8bd95a6ff54ea2c43bf53fa7091b0e7/types/xlsx), plus the changes from DefinitelyTyped/DefinitelyTyped/pull/16500. I've extracted the relevant commits from the DT repo and added it as a new root so all the history is preserved.

I have renamed all of the interfaces so they no longer start with `I`, but I notice that the Flow types have similar but not quite the same names as the TypeScript ones. Would it make sense to use something like [joarwilk/flowgen](/joarwilk/flowgen) to autogenerate the definitions of one from the other? That way they would always be in sync.

The build system is somewhat baffling--I added the references to dtslint to `package.json` but I'm not certain that's where they belong, and I wasn't sure where the linting belonged in the testing process. Also, I don't have a great deal of experience with TypeScript. On the whole, the changes I've made probably ought to be reviewed before they are merged in.

CC @DMan577, @DxCx, @groetzi, @Knagis, @nickveys, @paulvanbrenk, @rinzeb, @RyanCavanaugh, @StasD, @themauveavenger, @tmburnell who have all been involved in the development of the DefinitelyTyped definitions.