### PR TITLE
[fix] typescript definition for SSF, trying to ignore the warning

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,9 @@
 /** Version string */
 export const version: string;
 
+/** Defined SSF */
+export const SSF: any;
+
 /** Attempts to read filename and parse */
 export function readFile(filename: string, opts?: ParsingOptions): WorkBook;
 /** Attempts to parse data */


### PR DESCRIPTION
Here is my issue, [need updating definition for Typescript](https://github.com/SheetJS/js-xlsx/issues/711).
I just fix the definition and it works well with `awesome-typescript-loader`.
By the way, thanks for sheetjs and this great node module.