### PR TITLE
Fix potential infinite loop condition in test suite

### DIFF
--- a/test.js
+++ b/test.js
@@ -683,7 +683,7 @@ function custprop(wb) {
 	assert.equal(wb.Custprops.Counter, -3.14);
 }
 
-function cmparr(x){ for(var i=1;i!=x.length;++i) assert.deepEqual(x[0], x[i]); }
+function cmparr(x){ for(var i=1; i<x.length; ++i) assert.deepEqual(x[0], x[i]); }
 
 function deepcmp(x,y,k,m,c) {
 	var s = k.indexOf(".");


### PR DESCRIPTION
I was doing some testing with js-xlsx's test suite and ran into a test that was hanging.  The problem was cmparr()'s for-loop condition.  Switching from `!=` to `<` fixed the hung test and caused it to error correctly. Thought I'd drop the fix here in-case it's useful to js-xlsx.