### PR TITLE
Update tag regex to handle angle brackets in attributes, fixes Issue #768

### DIFF
--- a/bits/22_xmlutils.js
+++ b/bits/22_xmlutils.js
@@ -1,5 +1,5 @@
 var attregexg=/([^"\s?>\/]+)=((?:")([^"]*)(?:")|(?:')([^']*)(?:')|([^'">\s]+))/g;
-var tagregex=/<[^>]*>/g;
+var tagregex=/<[\/\?]?[a-zA-Z0-9:]+(?:\s+[^"\s?>\/]+=(?:"[^"]*"|'[^']*'|[^'">\s]+))*\s+?[\/\?]?>/g;
 var nsregex=/<\w*:/, nsregex2 = /<(\/?)\w+:/;
 function parsexmltag(tag/*:string*/, skip_root/*:?boolean*/)/*:any*/ {
 	var z = ({}/*:any*/);

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -1664,7 +1664,7 @@ function resolve_path(path/*:string*/, base/*:string*/)/*:string*/ {
 	return result.join('/');
 }
 var attregexg=/([^"\s?>\/]+)=((?:")([^"]*)(?:")|(?:')([^']*)(?:')|([^'">\s]+))/g;
-var tagregex=/<[^>]*>/g;
+var tagregex=/<[\/\?]?[a-zA-Z0-9:]+(?:\s[^"\s?>\/]+=(?:"[^"]*"|'[^']*'|[^'">\s]+))*\s?[\/\?]?>/g;
 var nsregex=/<\w*:/, nsregex2 = /<(\/?)\w+:/;
 function parsexmltag(tag/*:string*/, skip_root/*:?boolean*/)/*:any*/ {
 	var z = ({}/*:any*/);

--- a/xlsx.js
+++ b/xlsx.js
@@ -1600,7 +1600,7 @@ function resolve_path(path, base) {
 	return result.join('/');
 }
 var attregexg=/([^"\s?>\/]+)=((?:")([^"]*)(?:")|(?:')([^']*)(?:')|([^'">\s]+))/g;
-var tagregex=/<[^>]*>/g;
+var tagregex=/<[\/\?]?[a-zA-Z0-9:]+(?:\s[^"\s?>\/]+=(?:"[^"]*"|'[^']*'|[^'">\s]+))*\s?[\/\?]?>/g;
 var nsregex=/<\w*:/, nsregex2 = /<(\/?)\w+:/;
 function parsexmltag(tag, skip_root) {
 	var z = ({});


### PR DESCRIPTION
This fixes issue 768 by replacing the tagregex with one which ignores the contents of attributes for parsing XML