### PR TITLE
Fix fuzzydate string matching logic

### DIFF
--- a/bits/20_jsutils.js
+++ b/bits/20_jsutils.js
@@ -133,8 +133,8 @@ function fuzzydate(s/*:string*/)/*:Date*/ {
 	if(y < 0 || y > 8099) return n;
 	if((m > 0 || d > 1) && y != 101) return o;
 	if(s.toLowerCase().match(/jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/)) return o;
-	if(s.match(/[^-0-9:,\/\\]/)) return o;
-	return n;
+	if(s.match(/[^-0-9:,\/\\]/)) return n;
+	return o;
 }
 
 var safe_split_regex = "abacaba".split(/(:?b)/i).length == 5;

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -1600,8 +1600,8 @@ function fuzzydate(s/*:string*/)/*:Date*/ {
 	if(y < 0 || y > 8099) return n;
 	if((m > 0 || d > 1) && y != 101) return o;
 	if(s.toLowerCase().match(/jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/)) return o;
-	if(s.match(/[^-0-9:,\/\\]/)) return o;
-	return n;
+	if(s.match(/[^-0-9:,\/\\]/)) return n;
+	return o;
 }
 
 var safe_split_regex = "abacaba".split(/(:?b)/i).length == 5;

--- a/xlsx.js
+++ b/xlsx.js
@@ -1537,8 +1537,8 @@ function fuzzydate(s) {
 	if(y < 0 || y > 8099) return n;
 	if((m > 0 || d > 1) && y != 101) return o;
 	if(s.toLowerCase().match(/jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec/)) return o;
-	if(s.match(/[^-0-9:,\/\\]/)) return o;
-	return n;
+	if(s.match(/[^-0-9:,\/\\]/)) return n;
+	return o;
 }
 
 var safe_split_regex = "abacaba".split(/(:?b)/i).length == 5;


### PR DESCRIPTION
I'm seeing a bug in the fuzzydate function when uploading a CSV which includes a cell with the value `THIS IS A BUG 90` - it gets parsed to 1 January 1990. It looks to me like the update in commit 5b67ac0 to fix #772 altered the logic as to what constituted a date, but should also have swapped the returned values to reflect that updated logic.