### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2111,7 +2111,7 @@ the metadata the output is valid HTML, although it does accept bare `&` symbols.
 
 `make test` will run the node-based tests.  By default it runs tests on files in
 every supported format.  To test a specific file type, set `FMTS` to the format
-you want to test.  Feature-specific tests are avaialble with `make test_misc`
+you want to test.  Feature-specific tests are available with `make test_misc`
 
 ```bash
 $ make test_misc   # run core tests

--- a/bits/18_cfb.js
+++ b/bits/18_cfb.js
@@ -381,7 +381,7 @@ var ENDOFCHAIN = -2;
 var HEADER_SIGNATURE = 'd0cf11e0a1b11ae1';
 var HEADER_CLSID = '00000000000000000000000000000000';
 var consts = {
-	/* 2.1 Compund File Sector Numbers and Types */
+	/* 2.1 Compound File Sector Numbers and Types */
 	MAXREGSECT: -6,
 	DIFSECT: -4,
 	FATSECT: -3,

--- a/bits/40_harb.js
+++ b/bits/40_harb.js
@@ -149,7 +149,7 @@ function dbf_to_aoa(buf, opts)/*:AOA*/ {
 				case 'L': switch(s.toUpperCase()) {
 					case 'Y': case 'T': out[R][C] = true; break;
 					case 'N': case 'F': out[R][C] = false; break;
-					case ' ': case '?': out[R][C] = false; break; /* NOTE: technically unitialized */
+					case ' ': case '?': out[R][C] = false; break; /* NOTE: technically uninitialized */
 					default: throw new Error("DBF Unrecognized L:|" + s + "|");
 					} break;
 				case 'M': /* TODO: handle memo files */

--- a/bits/44_offcrypto.js
+++ b/bits/44_offcrypto.js
@@ -131,7 +131,7 @@ function parse_EncryptionInfo(blob, length/*:?number*/) {
 		case 0x03: return parse_EncInfoExt(blob, vers);
 		case 0x04: return parse_EncInfoAgl(blob, vers);
 	}
-	throw new Error("ECMA-376 Encryped file unrecognized Version: " + vers.Minor);
+	throw new Error("ECMA-376 Encrypted file unrecognized Version: " + vers.Minor);
 }
 
 /* [MS-OFFCRYPTO] 2.3.4.5  EncryptionInfo Stream (Standard Encryption) */

--- a/demos/headless/README.md
+++ b/demos/headless/README.md
@@ -1,6 +1,6 @@
 # Headless Browsers
 
-The library, intentionally conservative in the use of ES5+ feaures, plays nicely
+The library, intentionally conservative in the use of ES5+ features, plays nicely
 with most headless browsers.  This demo shows a few common headless scenarios.
 
 ## PhantomJS

--- a/demos/vue/SheetJS-vue.js
+++ b/demos/vue/SheetJS-vue.js
@@ -6,7 +6,7 @@ var SJSTemplate = [
 	'<div>',
 		'<input type="file" multiple="false" id="sheetjs-input" accept="' + SheetJSFT + '" @change="onchange" />',
 		'<br/>',
-		'<button type="button" id="expor-table" style="visibility:hidden" @click="onexport">Export to XLSX</button>',
+		'<button type="button" id="export-table" style="visibility:hidden" @click="onexport">Export to XLSX</button>',
 		'<br/>',
 		'<div id="out-table"></div>',
 	'</div>'
@@ -61,7 +61,7 @@ Vue.component('html-preview', {
 				/* update table */
 				document.getElementById('out-table').innerHTML = HTML;
 				/* show export button */
-				document.getElementById('expor-table').style.visibility = "visible";
+				document.getElementById('export-table').style.visibility = "visible";
 			};
 
 			reader.readAsArrayBuffer(file);

--- a/docbits/90_test.md
+++ b/docbits/90_test.md
@@ -7,7 +7,7 @@
 
 `make test` will run the node-based tests.  By default it runs tests on files in
 every supported format.  To test a specific file type, set `FMTS` to the format
-you want to test.  Feature-specific tests are avaialble with `make test_misc`
+you want to test.  Feature-specific tests are available with `make test_misc`
 
 ```bash
 $ make test_misc   # run core tests

--- a/misc/docs/README.md
+++ b/misc/docs/README.md
@@ -1923,7 +1923,7 @@ the metadata the output is valid HTML, although it does accept bare `&` symbols.
 
 `make test` will run the node-based tests.  By default it runs tests on files in
 every supported format.  To test a specific file type, set `FMTS` to the format
-you want to test.  Feature-specific tests are avaialble with `make test_misc`
+you want to test.  Feature-specific tests are available with `make test_misc`
 
 ```bash
 $ make test_misc   # run core tests

--- a/test.js
+++ b/test.js
@@ -1253,19 +1253,19 @@ describe('write features', function() {
 				X = require(modp);
 				ws = X.utils.aoa_to_sheet([["a","b","c"],[1,2,3]]);
 				baseprops = {
-					Category: "C4tegory",
-					ContentStatus: "C0ntentStatus",
-					Keywords: "K3ywords",
-					LastAuthor: "L4stAuthor",
-					LastPrinted: "L4stPrinted",
+					Category: "Newspaper",
+					ContentStatus: "Published",
+					Keywords: "print",
+					LastAuthor: "Perry White",
+					LastPrinted: "1978-12-15",
 					RevNumber: 6969,
 					AppVersion: 69,
-					Author: "4uth0r",
-					Comments: "C0mments",
+					Author: "Lois Lane",
+					Comments: "Needs work",
 					Identifier: "1d",
-					Language: "L4nguage",
-					Subject: "Subj3ct",
-					Title: "T1tle"
+					Language: "English",
+					Subject: "Superman",
+					Title: "Man of Steel"
 				};
 			});
 			if(typeof before != 'undefined') before(bef);
@@ -2016,7 +2016,7 @@ describe('encryption', function() {
 			it('should throw with no password', function() {assert.throws(function() { X.read(fs.readFileSync(dir + x), {type:TYPE}); }); });
 			it('should throw with wrong password', function() {
 				try {
-					X.read(fs.readFileSync(dir + x), {type:TYPE,password:'passwor',WTF:opts.WTF});
+					X.read(fs.readFileSync(dir + x), {type:TYPE,password:'Password',WTF:opts.WTF});
 					throw new Error("incorrect password was accepted");
 				} catch(e) {
 					if(e.message != "Password is incorrect") throw e;

--- a/tests/core.js
+++ b/tests/core.js
@@ -2016,7 +2016,7 @@ describe('encryption', function() {
 			it('should throw with no password', function() {assert.throws(function() { X.read(fs.readFileSync(dir + x), {type:TYPE}); }); });
 			it('should throw with wrong password', function() {
 				try {
-					X.read(fs.readFileSync(dir + x), {type:TYPE,password:'passwor',WTF:opts.WTF});
+					X.read(fs.readFileSync(dir + x), {type:TYPE,password:'Password',WTF:opts.WTF});
 					throw new Error("incorrect password was accepted");
 				} catch(e) {
 					if(e.message != "Password is incorrect") throw e;


### PR DESCRIPTION
You can of course drop commits.
The filename change is a bit odd -> SheetJS/jxls#2 (someone would have to fix this repo once that PR is taken, if it is).

The password change is because it's an annoying false positive. afaict, there's no particular requirement to misspell the word by omitting a character, and thus it's nicer for spelling tools if you just append a suffix which should also result in a non-matching password. There's also a family of tokens such as `C4tegory`.