### PR TITLE
Parse text:s elements containing text:c attributes

### DIFF
--- a/bits/80_parseods.js
+++ b/bits/80_parseods.js
@@ -2,7 +2,7 @@
 var parse_content_xml = (function() {
 
 	var parse_text_p = function(text, tag) {
-		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<[^>]*>/g,""));
+		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<text:s text:c="(\d+)"\/>/g, function($$,$1) { return Array(parseInt($1)+1).join(" "); }).replace(/<[^>]*>/g,""));
 	};
 
 	var number_formats = {

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -17004,7 +17004,7 @@ function table_to_book(table/*:HTMLElement*/, opts/*:?any*/)/*:Workbook*/ {
 var parse_content_xml = (function() {
 
 	var parse_text_p = function(text, tag) {
-		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<[^>]*>/g,""));
+		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<text:s text:c="(\d+)"\/>/g, function($$,$1) { return Array(parseInt($1)+1).join(" "); }).replace(/<[^>]*>/g,""));
 	};
 
 	var number_formats = {

--- a/xlsx.js
+++ b/xlsx.js
@@ -16906,7 +16906,7 @@ function table_to_book(table, opts) {
 var parse_content_xml = (function() {
 
 	var parse_text_p = function(text, tag) {
-		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<[^>]*>/g,""));
+		return unescapexml(text.replace(/<text:s\/>/g," ").replace(/<text:s text:c="(\d+)"\/>/g, function($$,$1) { return Array(parseInt($1)+1).join(" "); }).replace(/<[^>]*>/g,""));
 	};
 
 	var number_formats = {


### PR DESCRIPTION
Fixes bug #835 where `<text:s>` elements containing c attributes are not read by the parser