### PR TITLE
Add columns with empty headers to JSON output

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -18815,7 +18815,7 @@ function sheet_to_json(sheet, opts) {
 			case 2: hdr[C] = cols[C]; break;
 			case 3: hdr[C] = o.header[C - r.s.c]; break;
 			default:
-				if(val == null) continue;
+				if(val == null) val = {w: "__EMPTY", t: "s"};
 				vv = v = format_cell(val, null, o);
 				counter = 0;
 				for(CC = 0; CC < hdr.length; ++CC) if(hdr[CC] == vv) vv = v + "_" + (++counter);


### PR DESCRIPTION
With current sheet_to_json function, when using first row as data headers, when a column's first cell is empty, the whole column is not included in the result.
With this small PR, columns with empty header are included in the result, with the special "__EMPTY" key.
If there are multiple empty columns, they get the numbered "__EMPTY", "__EMPTY_1", "__EMPTY_2", etc...