### PR TITLE
bug fix: when the arrayBuffer is to large, __toBuffer will cause error

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -2255,7 +2255,7 @@ function write_double_le(b, v, idx) {
 	b[idx + 7] = (e >> 4) | bs;
 }
 
-var __toBuffer = function(bufs) { var x = []; for(var i = 0; i < bufs[0].length; ++i) { x.push.apply(x, bufs[0][i]); } return x; };
+var __toBuffer = function(bufs) { var x = [],QUANTUM = 32768; for(var i = 0; i < bufs[0].length; ++i) { for(var j=0,len= bufs[0][i].length; j<len;j+=QUANTUM) { buf_arr = bufs[0][i].slice(j,Math.min(j+QUANTUM,len));x.push.apply(x, buf_arr); }} return x; };
 var ___toBuffer = __toBuffer;
 var __utf16le = function(b,s,e) { var ss=[]; for(var i=s; i<e; i+=2) ss.push(String.fromCharCode(__readUInt16LE(b,i))); return ss.join("").replace(chr0,''); };
 var ___utf16le = __utf16le;


### PR DESCRIPTION
The __toBuufer function use "x.push.apply",but the argument has limits. when the length of array is larger than 65536, it will cause an error: Maximum call stack size exceeded.(refer to: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
so i apply chunks of the array at a time.
