### PR TITLE
Module name should be consistently used in examples

### DIFF
--- a/demos/electron/README.md
+++ b/demos/electron/README.md
@@ -24,7 +24,7 @@ var dialog = require('electron').remote.dialog;
 
 /* show a file-open dialog and read the first selected file */
 var o = dialog.showOpenDialog({ properties: ['openFile'] });
-var workbook = X.readFile(o[0]);
+var workbook = XLSX.readFile(o[0]);
 
 /* show a file-save dialog and write the workbook */
 var o = dialog.showSaveDialog();


### PR DESCRIPTION
Module name in the readFile example code should be identical to the one used with the writeFile example and a prior example where XLSX is defined as the object the require('xlsx') returns