### PR TITLE
Fixes xlsb file parsing with BrtRevisionPtr

### DIFF
--- a/bits/73_wbbin.js
+++ b/bits/73_wbbin.js
@@ -130,9 +130,9 @@ function parse_wb_bin(data, opts)/*:WorkbookFile*/ {
 			case 0x0169: /* 'BrtPlaceholderName' */
 				break;
 
-			/* case 'BrtModelTimeGroupingCalcCol' */
-			/* case 'BrtRevisionPtr' */
+			/* case 'BrtModelTimeGroupingCalcCol' */			
 			/* case 'BrtUid' */
+			case 0x0C01: /* 'BrtRevisionPtr' */
 			case 0x0817: /* 'BrtAbsPath15' */
 			case 0x0216: /* 'BrtBookProtection' */
 			case 0x02A5: /* 'BrtBookProtectionIso' */


### PR DESCRIPTION
This addresses #1041 (BrtRevisionPtr breaks parsing) by ignoring it.