### PR TITLE
add px unit to font-size

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -7057,7 +7057,7 @@ var parse_rs = (function parse_rs_factory() {
 
 		if(font.u) style.push("text-decoration: underline;");
 		if(font.uval) style.push("text-underline-style:" + font.uval + ";");
-		if(font.sz) style.push("font-size:" + font.sz + ";");
+		if(font.sz) style.push("font-size:" + font.sz + "px;");
 		if(font.outline) style.push("text-effect: outline;");
 		if(font.shadow) style.push("text-shadow: auto;");
 		intro.push('<span style="' + style.join("") + '">');


### PR DESCRIPTION
Chrome marks font-size as invalid without a font size unit.

![font_size_invalid](https://user-images.githubusercontent.com/595469/38893673-9ac25d8c-4250-11e8-879a-1a0226e28bce.png)
