### PR TITLE
Support x: tags in styles.xml

### DIFF
--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -8250,6 +8250,7 @@ function parse_cellXfs(t, styles, opts) {
 	var pass = false;
 	t[0].match(tagregex).forEach(function(x) {
 		var y = parsexmltag(x), i = 0;
+		y[0] = y[0].replace(/x:/g, '');
 		switch(y[0]) {
 			case '<cellXfs': case '<cellXfs>': case '<cellXfs/>': case '</cellXfs>': break;
 
@@ -8305,11 +8306,11 @@ function write_cellXfs(cellXfs)/*:string*/ {
 
 /* 18.8 Styles CT_Stylesheet*/
 var parse_sty_xml= (function make_pstyx() {
-var numFmtRegex = /<numFmts([^>]*)>[\S\s]*?<\/numFmts>/;
-var cellXfRegex = /<cellXfs([^>]*)>[\S\s]*?<\/cellXfs>/;
-var fillsRegex = /<fills([^>]*)>[\S\s]*?<\/fills>/;
-var fontsRegex = /<fonts([^>]*)>[\S\s]*?<\/fonts>/;
-var bordersRegex = /<borders([^>]*)>[\S\s]*?<\/borders>/;
+var numFmtRegex = /<(x:)?numFmts([^>]*)>[\S\s]*?<\/(x:)?numFmts>/;
+var cellXfRegex = /<(x:)?cellXfs([^>]*)>[\S\s]*?<\/(x:)?cellXfs>/;
+var fillsRegex = /<(x:)?fills([^>]*)>[\S\s]*?<\/(x:)?fills>/;
+var fontsRegex = /<(x:)?fonts([^>]*)>[\S\s]*?<\/(x:)?fonts>/;
+var bordersRegex = /<(x:)?borders([^>]*)>[\S\s]*?<\/(x:)?borders>/;
 
 return function parse_sty_xml(data, themes, opts) {
 	var styles = {};

--- a/xlsx.js
+++ b/xlsx.js
@@ -8155,6 +8155,7 @@ function parse_cellXfs(t, styles, opts) {
 	var pass = false;
 	t[0].match(tagregex).forEach(function(x) {
 		var y = parsexmltag(x), i = 0;
+		y[0] = y[0].replace(/x:/g, '');
 		switch(y[0]) {
 			case '<cellXfs': case '<cellXfs>': case '<cellXfs/>': case '</cellXfs>': break;
 
@@ -8210,11 +8211,11 @@ function write_cellXfs(cellXfs) {
 
 /* 18.8 Styles CT_Stylesheet*/
 var parse_sty_xml= (function make_pstyx() {
-var numFmtRegex = /<numFmts([^>]*)>[\S\s]*?<\/numFmts>/;
-var cellXfRegex = /<cellXfs([^>]*)>[\S\s]*?<\/cellXfs>/;
-var fillsRegex = /<fills([^>]*)>[\S\s]*?<\/fills>/;
-var fontsRegex = /<fonts([^>]*)>[\S\s]*?<\/fonts>/;
-var bordersRegex = /<borders([^>]*)>[\S\s]*?<\/borders>/;
+var numFmtRegex = /<(x:)?numFmts([^>]*)>[\S\s]*?<\/(x:)?numFmts>/;
+var cellXfRegex = /<(x:)?cellXfs([^>]*)>[\S\s]*?<\/(x:)?cellXfs>/;
+var fillsRegex = /<(x:)?fills([^>]*)>[\S\s]*?<\/(x:)?fills>/;
+var fontsRegex = /<(x:)?fonts([^>]*)>[\S\s]*?<\/(x:)?fonts>/;
+var bordersRegex = /<(x:)?borders([^>]*)>[\S\s]*?<\/(x:)?borders>/;
 
 return function parse_sty_xml(data, themes, opts) {
 	var styles = {};


### PR DESCRIPTION
The XML tags in `styles.xml` sometimes have an extra `x:` which messes up `parse_sty_xml`

    <x:cellXfs count="2">
        <x:xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" />
        <x:xf numFmtId="14" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" />
    </x:cellXfs>

(see https://social.msdn.microsoft.com/Forums/vstudio/en-US/a72442fd-a1a6-446e-9416-876f7669d8e2/openxml-excel-date-formatting for more examples)

This is a simple fix for the problem