### PR TITLE
Allow cell objects to be passed in when importing data from JSON

### DIFF
--- a/bits/90_utils.js
+++ b/bits/90_utils.js
@@ -196,16 +196,20 @@ function sheet_add_json(_ws/*:?Worksheet*/, js/*:Array<any>*/, opts)/*:Worksheet
 			var v = JS[k];
 			var t = 'z';
 			var z = "";
-			if(typeof v == 'number') t = 'n';
-			else if(typeof v == 'boolean') t = 'b';
-			else if(typeof v == 'string') t = 's';
-			else if(v instanceof Date) {
-				t = 'd';
-				if(!o.cellDates) { t = 'n'; v = datenum(v); }
-				z = o.dateNF || SSF._table[14];
-			}
-			ws[encode_cell({c:_C + C,r:_R + R + offset})] = cell = ({t:t, v:v}/*:any*/);
-			if(z) cell.z = z;
+            if(v && typeof v === 'object' && !(v instanceof Date)){
+                ws[encode_cell({c:_C + C,r:_R + R + offset})] = v;
+            } else {
+                if(typeof v == 'number') t = 'n';
+                else if(typeof v == 'boolean') t = 'b';
+                else if(typeof v == 'string') t = 's';
+                else if(v instanceof Date) {
+                    t = 'd';
+                    if(!o.cellDates) { t = 'n'; v = datenum(v); }
+                    z = o.dateNF || SSF._table[14];
+                }
+                ws[encode_cell({c:_C + C,r:_R + R + offset})] = cell = ({t:t, v:v}/*:any*/);
+                if(z) cell.z = z;
+            }
 		});
 	});
 	range.e.c = Math.max(range.e.c, _C + hdr.length - 1);


### PR DESCRIPTION
This relates to https://github.com/SheetJS/js-xlsx/issues/1168 – it basically implements the fix that @SheetJSDev suggests, which I've confirmed works on my test case in the code listed there.

Essentially this allows us to pass a structured cell object into utilities like `json_to_sheet()`, eg:

```
let myArray = [
  {
    name: 'bob',
    age: 23,
    link: {
        f: 'HYPERLINK("http://www.google.com", "Google")',
        t: 'n',
        v: 'http://www.google.com'
    }
  }
];

let worksheet = XLSX.utils.json_to_sheet(myArray);
let workbook = XLSX.utils.book_new();
XLSX.utils.book_append_sheet(workbook, worksheet, "SheetJS");
```

Note: I couldn't get the indentation to work properly for this PR – I tried in two different editors and despite telling both to use spaces, not tabs, the output of this PR is different from how the code looks in both IntelliJ and VS Code:

![image](https://user-images.githubusercontent.com/394376/42219151-c270db8e-7ec2-11e8-8210-b56480b744a2.png)

Is there a required editor config to make this work?