### PR TITLE
feat: support cell object in the function 'sheet_add_aoa'

### DIFF
--- a/bits/27_csfutils.js
+++ b/bits/27_csfutils.js
@@ -105,7 +105,10 @@ function sheet_add_aoa(_ws/*:?Worksheet*/, data/*:AOA*/, opts/*:?any*/)/*:Worksh
 		if(!Array.isArray(data[R])) throw new Error("aoa_to_sheet expects an array of arrays");
 		for(var C = 0; C != data[R].length; ++C) {
 			if(typeof data[R][C] === 'undefined') continue;
-			var cell/*:Cell*/ = ({v: data[R][C] }/*:any*/);
+      var cell/*:Cell*/ = ({v: data[R][C] }/*:any*/);
+      if(data[R][C] && typeof data[R][C] === 'object' && Object.prototype.toString.call(data[R][C] ).toLowerCase() === "[object object]"){
+          cell = data[R][C]
+      }
 			if(Array.isArray(cell.v)) { cell.f = data[R][C][1]; cell.v = cell.v[0]; }
 			var __R = _R + R, __C = _C + C;
 			if(range.s.r > __R) range.s.r = __R;

--- a/test.js
+++ b/test.js
@@ -2374,3 +2374,25 @@ mft.forEach(function(x) {
 	}});
 }); });
 
+describe('support object cell', function() {
+  var data = require('./').utils.sheet_add_aoa (null, [
+    ['url', 'name', 'id'],
+    [
+      {
+        l: {
+          Target: 'https://123.com',
+        },
+        v: 'url',
+        t: 's',
+      },
+      'tom',
+      'xxx'
+    ],
+  ]);
+  it('base', function(){
+    assert.deepEqual(data.A2,  { l: { Target: 'https://123.com' },
+    v: 'url',
+    t: 's' })
+  })
+})
+

--- a/xlsx.flow.js
+++ b/xlsx.flow.js
@@ -3683,7 +3683,10 @@ function sheet_add_aoa(_ws/*:?Worksheet*/, data/*:AOA*/, opts/*:?any*/)/*:Worksh
 		if(!Array.isArray(data[R])) throw new Error("aoa_to_sheet expects an array of arrays");
 		for(var C = 0; C != data[R].length; ++C) {
 			if(typeof data[R][C] === 'undefined') continue;
-			var cell/*:Cell*/ = ({v: data[R][C] }/*:any*/);
+      var cell/*:Cell*/ = ({v: data[R][C] }/*:any*/);
+      if(data[R][C] && typeof data[R][C] === 'object' && Object.prototype.toString.call(data[R][C] ).toLowerCase() === "[object object]"){
+          cell = data[R][C]
+      }
 			if(Array.isArray(cell.v)) { cell.f = data[R][C][1]; cell.v = cell.v[0]; }
 			var __R = _R + R, __C = _C + C;
 			if(range.s.r > __R) range.s.r = __R;

--- a/xlsx.js
+++ b/xlsx.js
@@ -3593,7 +3593,7 @@ function sheet_add_aoa(_ws, data, opts) {
 			if(typeof data[R][C] === 'undefined') continue;
       var cell = ({v: data[R][C] });
       if(data[R][C] && typeof data[R][C] === 'object' && Object.prototype.toString.call(data[R][C] ).toLowerCase() === "[object object]"){
-        cell = data[R][C]
+          cell = data[R][C]
       }
 			if(Array.isArray(cell.v)) { cell.f = data[R][C][1]; cell.v = cell.v[0]; }
 			var __R = _R + R, __C = _C + C;

--- a/xlsx.js
+++ b/xlsx.js
@@ -3591,7 +3591,10 @@ function sheet_add_aoa(_ws, data, opts) {
 		if(!Array.isArray(data[R])) throw new Error("aoa_to_sheet expects an array of arrays");
 		for(var C = 0; C != data[R].length; ++C) {
 			if(typeof data[R][C] === 'undefined') continue;
-			var cell = ({v: data[R][C] });
+      var cell = ({v: data[R][C] });
+      if(data[R][C] && typeof data[R][C] === 'object' && Object.prototype.toString.call(data[R][C] ).toLowerCase() === "[object object]"){
+        cell = data[R][C]
+      }
 			if(Array.isArray(cell.v)) { cell.f = data[R][C][1]; cell.v = cell.v[0]; }
 			var __R = _R + R, __C = _C + C;
 			if(range.s.r > __R) range.s.r = __R;


### PR DESCRIPTION
Support cell object , make js-xlsx easier to use.

```js
describe('support object cell', function() {
  var data = require('./').utils.sheet_add_aoa (null, [
    ['url', 'name', 'id'],
    [
      {
        l: {
          Target: 'https://123.com',
        },
        v: 'url',
        t: 's',
      },
      'tom',
      'xxx'
    ],
  ]);
  it('base', function(){
    assert.deepEqual(data.A2,  { l: { Target: 'https://123.com' },
    v: 'url',
    t: 's' })
  })
})


```