### PR TITLE
Adding option to always get raw data

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -3552,6 +3552,7 @@ function safe_format_cell(cell, v) {
 
 function format_cell(cell, v, o) {
 	if(cell == null || cell.t == null || cell.t == 'z') return "";
+	if(o && o.raw && cell.v) return cell.v;
 	if(cell.w !== undefined) return cell.w;
 	if(cell.t == 'd' && !cell.z && o && o.dateNF) cell.z = o.dateNF;
 	if(v == undefined) return safe_format_cell(cell, cell.v);


### PR DESCRIPTION
This wasn't possible before and would be useful if you want to get the raw data from a cell while using functions like `stream.to_csv`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sheetjs/js-xlsx/1296)
<!-- Reviewable:end -->
