### PR TITLE
Fix cornercase of to_csv with skipHidden enabled

### DIFF
--- a/bits/97_node.js
+++ b/bits/97_node.js
@@ -18,7 +18,6 @@ if(has_buf && typeof require != 'undefined') (function() {
 		var BOM = false;
 		stream._read = function() {
 			if(!BOM) { BOM = true; return stream.push("\uFEFF"); }
-			if(R > r.e.r) return stream.push(null);
 			while(R <= r.e.r) {
 				++R;
 				if ((rowinfo[R-1]||{}).hidden) continue;
@@ -29,6 +28,7 @@ if(has_buf && typeof require != 'undefined') (function() {
 					break;
 				}
 			}
+			if(R > r.e.r) return stream.push(null);
 		};
 		return stream;
 	};


### PR DESCRIPTION
When running `xlsx.stream.to_csv(sheet, { skipHidden: true })` on the only sheet in [this XLS-file from the Swedish Pension Authority](https://www.pensionsmyndigheten.se/content/dam/pensionsmyndigheten/blanketter---broschyrer---faktablad/statistik/premiepension/fonddata/nuvarande-och-tidigare-fonder/Lista%20alla%20fonder%20.xls) the stream never got to `on('end')`. I think it's because all the rows in the last `_read` call was set to hidden, leaving the stream kept in limbo. This seems to have fixed it and makes sense to me but I'm not very familiar with node streams.