### PR TITLE
Fix for Issue: #1421 - TSV with empty first cell recognized wrong

### DIFF
--- a/bits/87_read.js
+++ b/bits/87_read.js
@@ -82,7 +82,7 @@ function readSync(data/*:RawData*/, opts/*:?ParseOpts*/)/*:Workbook*/ {
 	}
 	switch((n = firstbyte(d, o))[0]) {
 		case 0xD0: return read_cfb(CFB.read(d, o), o);
-		case 0x09: return parse_xlscfb(d, o);
+		case 0x09: if(n[1] <= 0x04) return parse_xlscfb(d, o); break;
 		case 0x3C: return parse_xlml(d, o);
 		case 0x49: if(n[1] === 0x44) return read_wb_ID(d, o); break;
 		case 0x54: if(n[1] === 0x41 && n[2] === 0x42 && n[3] === 0x4C) return DIF.to_workbook(d, o); break;


### PR DESCRIPTION
Updated bits/87_read.js per SheeJSDev's comments (https://github.com/SheetJS/js-xlsx/issues/1421#issuecomment-537808818)

Made sure that I was able to perform the make process:
```console
$ git add xlsx.js
$ make clean
$ make
$ git diff xlsx.js
```

Closes #1421 