### PR TITLE
Add unpkg and jsdelivr fields to allow CDNs to automatically pick compatible modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"xlsx": "./bin/xlsx.njs"
 	},
 	"main": "./xlsx",
+	"unpkg": "dist/xlsx.min.js",
+	"jsdelivr": "dist/xlsx.min.js",
 	"types": "types",
 	"browser": {
 		"buffer": false,


### PR DESCRIPTION
This PR adds `unpkg` and `jsdelivr` fields to allow those CDNs to automatically serve the correct module from a URL like `unpkg.com/xlsx@0.15.1` and for tools to automatically load the right file, instead of web tools getting the default CommonJS entrypoint.